### PR TITLE
fix(eodi-batch): 아파트 매매 데이터 API 임시 파일명 job context에 잘못 저장되던 오류 수정

### DIFF
--- a/backend/eodi-batch/src/main/java/com/bb/eodi/batch/deal/load/tasklet/ApartmentSaleApiFetchStepTasklet.java
+++ b/backend/eodi-batch/src/main/java/com/bb/eodi/batch/deal/load/tasklet/ApartmentSaleApiFetchStepTasklet.java
@@ -55,7 +55,7 @@ public class ApartmentSaleApiFetchStepTasklet implements Tasklet {
                 .collect(Collectors.toList());
 
         // temp file 생성
-        Path tempFilePath = Files.createTempFile(jobCtx.getString(APT_SALE_TEMP_FILE.name()), null);
+        Path tempFilePath = Files.createTempFile(APT_SALE_TEMP_FILE.name(), null);
 
         /**
          * 전국 대상 API 요청 후 파일에 작성
@@ -79,6 +79,12 @@ public class ApartmentSaleApiFetchStepTasklet implements Tasklet {
             Files.delete(tempFilePath);
             throw new RuntimeException(e);
         }
+
+        /**
+         * 임시 파일명 jobContext에 저장
+         */
+        jobCtx.putString(APT_SALE_TEMP_FILE.name(), tempFilePath.toString());
+
 
         return RepeatStatus.FINISHED;
     }

--- a/backend/eodi-batch/src/main/java/com/bb/eodi/batch/deal/load/tasklet/MonthlyDealDataLoadPreprocessStepTasklet.java
+++ b/backend/eodi-batch/src/main/java/com/bb/eodi/batch/deal/load/tasklet/MonthlyDealDataLoadPreprocessStepTasklet.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Component;
 @StepScope
 public class MonthlyDealDataLoadPreprocessStepTasklet implements Tasklet {
 
-    private final MonthlyDealDataLoadJobProperties properties;
     private final String dealMonth;
 
     public MonthlyDealDataLoadPreprocessStepTasklet(
@@ -26,7 +25,6 @@ public class MonthlyDealDataLoadPreprocessStepTasklet implements Tasklet {
             MonthlyDealDataLoadJobProperties properties
     ) {
         this.dealMonth = dealMonth;
-        this.properties = properties;
     }
 
     @Override
@@ -34,7 +32,6 @@ public class MonthlyDealDataLoadPreprocessStepTasklet implements Tasklet {
         ExecutionContext jobCtx = contribution.getStepExecution().getJobExecution().getExecutionContext();
 
         jobCtx.putString(MonthlyDealDataLoadJobKey.DEAL_MONTH.name(), dealMonth);
-        jobCtx.putString(MonthlyDealDataLoadJobKey.APT_SALE_TEMP_FILE.name(), properties.aptSaleTempFileName());
 
         return null;
     }


### PR DESCRIPTION
파일 키로만 컨텍스트에 저장되어 이후 스텝에서 파일 명을 참조하지 못해 컨텍스트에 저장되는 데이터를 임시 파일 물리명으로 변경